### PR TITLE
when use backend theme true not worked

### DIFF
--- a/Providers/UserServiceProvider.php
+++ b/Providers/UserServiceProvider.php
@@ -22,6 +22,7 @@ use Modules\User\Repositories\RoleRepository;
 use Modules\User\Repositories\UserRepository;
 use Modules\User\Repositories\UserTokenRepository;
 use Modules\User\Guards\Sentinel;
+use Modules\Workshop\Manager\StylistThemeManager;
 
 class UserServiceProvider extends ServiceProvider
 {
@@ -70,13 +71,18 @@ class UserServiceProvider extends ServiceProvider
 
     /**
      */
-    public function boot()
+    public function boot(StylistThemeManager $theme)
     {
         $this->registerMiddleware();
 
         $this->publishes([
             __DIR__ . '/../Resources/views' => base_path('resources/views/asgard/user'),
         ]);
+
+        $this->app['view']->prependNamespace(
+            'user',
+            $theme->find(config('asgard.core.core.admin-theme'))->getPath() . '/views/modules/user'
+        );
 
         $this->publishConfig('user', 'permissions');
         $this->publishConfig('user', 'config');


### PR DESCRIPTION
this option for user model not work 
// Read module views from /Themes/<backend-theme-name>/views/modules/<module-name>
backend-theme' => true,

This problem also on other core module , because i want create new backend theme.
but I solve that.
******
'enable-theme-overrides' => true,
ok , don't need this line ,but why user provider has this lines of code and other don't have!